### PR TITLE
Fix compilation problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,12 @@ _testmain.go
 *.exe
 *.test
 teeproxy
+teeproxy_unix
 
 pkg/
 src/
 #src/github.com
 #src/github.org
 #src/gopkg.in
+
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 BINARY_NAME=teeproxy
-#BINARY_UNIX=$(BINARY_NAME)_unix
+BINARY_UNIX=$(BINARY_NAME)_unix
     
 all: clean deps build
 build: 
@@ -26,5 +26,5 @@ deps:
     
     
 # Cross compilation
-#build-linux:
-#	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_UNIX) -v
+build-linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_UNIX) -v

--- a/teeproxy.go
+++ b/teeproxy.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"time"
 
-	proxy "./http"
+	proxy "teeproxy/http"
 
 	"github.com/NYTimes/logrotate"
 	logrus "github.com/sirupsen/logrus"


### PR DESCRIPTION
@rajesh-r I'm not sure how you were able to compile this before, but I was not able to run `make build` in the root directory of the project naturally in this repo after cloning it.  I was getting this error:
```
teeproxy.go:13:2: local import "./http" in non-local package
```

This fixes that.  Did you have any local environment setup that made compilation work for you?